### PR TITLE
Show fields counts coverages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import Dict, List, Optional
+
 
 from arche.readers.items import CollectionItems, JobItems
 from arche.rules.result import Result
+import pandas as pd
 import pytest
 
 
@@ -176,3 +178,9 @@ def create_result(
     if items_count:
         result.items_count = items_count
     return result
+
+
+def create_named_df(data: Dict, index: List[str], name: str) -> pd.DataFrame:
+    df = pd.DataFrame(data, index=index)
+    df.name = name
+    return df

--- a/tests/rules/test_category.py
+++ b/tests/rules/test_category.py
@@ -1,8 +1,6 @@
-from typing import Dict, List
-
 import arche.rules.category as c
 from arche.rules.result import Level
-from conftest import create_result
+from conftest import create_result, create_named_df
 import numpy as np
 import pandas as pd
 import pytest
@@ -39,12 +37,6 @@ def test_get_coverage_per_category(data, cat_names, expected_messages):
     )
 
 
-def create_df(data: Dict, index: List[str], name: str) -> pd.DataFrame:
-    df = pd.DataFrame(data, index=index)
-    df.name = "Coverage difference in sex"
-    return df
-
-
 @pytest.mark.parametrize(
     "source, target, categories, expected_messages",
     [
@@ -70,7 +62,7 @@ def create_df(data: Dict, index: List[str], name: str) -> pd.DataFrame:
                         "'sex' PASSED",
                         None,
                         None,
-                        create_df(
+                        create_named_df(
                             {"s": [25.0, 25.0, 50.0], "t": [0.0, 33.33, 66.67]},
                             index=[np.nan, "female", "male"],
                             name="Coverage difference in sex",
@@ -80,7 +72,7 @@ def create_df(data: Dict, index: List[str], name: str) -> pd.DataFrame:
                         "'country' PASSED",
                         None,
                         None,
-                        create_df(
+                        create_named_df(
                             {"s": [25.0, 75.0], "t": [0.0, 100.0]},
                             index=["us", "uk"],
                             name="Coverage difference in country",
@@ -90,7 +82,7 @@ def create_df(data: Dict, index: List[str], name: str) -> pd.DataFrame:
                         "'age' PASSED",
                         None,
                         None,
-                        create_df(
+                        create_named_df(
                             {"s": [100.0], "t": [100.0]},
                             index=[25],
                             name="Coverage difference in age",

--- a/tests/rules/test_coverage.py
+++ b/tests/rules/test_coverage.py
@@ -1,6 +1,6 @@
 import arche.rules.coverage as cov
 from arche.rules.result import Level
-from conftest import create_result, Job
+from conftest import create_result, create_named_df, Job
 import pandas as pd
 import pytest
 
@@ -16,7 +16,7 @@ import pytest
                         "PASSED",
                         None,
                         None,
-                        pd.Series([1], index=["_key"], name="Fields Coverage"),
+                        pd.Series([1], index=["_key"], name="Fields coverage"),
                     )
                 ]
             },
@@ -30,7 +30,7 @@ import pytest
                         None,
                         None,
                         pd.Series(
-                            [1, 0], index=["Name", "Field"], name="Fields Coverage"
+                            [1, 0], index=["Name", "Field"], name="Fields coverage"
                         ),
                     )
                 ]
@@ -45,7 +45,7 @@ import pytest
                         None,
                         None,
                         pd.Series(
-                            [1, 1], index=["Field", "Name"], name="Fields Coverage"
+                            [1, 1], index=["Field", "Name"], name="Fields coverage"
                         ),
                     )
                 ]
@@ -71,10 +71,10 @@ def test_check_fields_coverage(df, expected_messages):
                         "",
                         None,
                         None,
-                        pd.Series(
-                            [50.0, 100.0, 150.0],
-                            index=["f2", "f1", "f3"],
-                            name="Coverage difference between 0 and 1",
+                        create_named_df(
+                            {"s": [0.0, 100.0, 150.0], "t": [150.0, 0.0, 100.0]},
+                            index=["f3", "f1", "f2"],
+                            name="Coverage difference in fields counts",
                         ),
                     )
                 ],
@@ -93,10 +93,10 @@ def test_check_fields_coverage(df, expected_messages):
                         "",
                         None,
                         None,
-                        pd.Series(
-                            [5.5, 47.0],
-                            index=["f2", "f1"],
-                            name="Coverage difference between 0 and 1",
+                        create_named_df(
+                            {"s": [100.0, 150.0], "t": [53.0, 144.5]},
+                            index=["f1", "f2"],
+                            name="Coverage difference in fields counts",
                         ),
                     )
                 ],
@@ -114,10 +114,10 @@ def test_check_fields_coverage(df, expected_messages):
                         "",
                         None,
                         None,
-                        pd.Series(
-                            [6.0, 9.0],
+                        create_named_df(
+                            {"s": [100.0, 150.0], "t": [94.0, 141.0]},
                             index=["f1", "f2"],
-                            name="Coverage difference between 0 and 1",
+                            name="Coverage difference in fields counts",
                         ),
                     )
                 ],
@@ -126,13 +126,26 @@ def test_check_fields_coverage(df, expected_messages):
         (
             {"counts": {"state": 100}, "totals": {"input_values": 100}},
             {"counts": {"state": 100}, "totals": {"input_values": 100}},
-            {},
+            {
+                Level.INFO: [
+                    (
+                        "PASSED",
+                        None,
+                        None,
+                        create_named_df(
+                            {"s": [100.0], "t": [100.0]},
+                            index=["state"],
+                            name="Coverage difference in fields counts",
+                        ),
+                    )
+                ]
+            },
         ),
     ],
 )
 def test_get_difference(source_stats, target_stats, expected_messages):
     result = cov.get_difference(
-        Job(stats=source_stats, key="0"), Job(stats=target_stats, key="1")
+        Job(stats=source_stats, key="s"), Job(stats=target_stats, key="t")
     )
     assert result == create_result("Coverage Difference", expected_messages)
 


### PR DESCRIPTION
Now it returns fields counts coverages for both jobs which I think is more obvious.
One thing to note is that the coverage can be >100% since scrapy cloud stats counts array fields too.
Before:
![Screenshot 2019-04-04 at 13 57 11](https://user-images.githubusercontent.com/10396557/55574071-ddc7cd00-56e1-11e9-83b2-86cb3ad7ffe0.png)

Now:
![Screenshot 2019-04-04 at 13 57 11](https://user-images.githubusercontent.com/10396557/55573993-b113b580-56e1-11e9-9a3e-19a8ee962f49.png)

I am not personally sure that the previous one was worse.
