### PR TITLE
Remove responses ratio

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Note that the top-most release is changes in the unreleased master branch on Git
 - `data_quality_report()`, #95
 - Wrong number of Collection Items if it contains item 0, #112
 ### Removed
+- **Responses Per Item Ratio** rule
 
 
 ## [0.3.5] (2019-05-14)

--- a/src/arche/arche.py
+++ b/src/arche/arche.py
@@ -216,7 +216,6 @@ class Arche:
     def check_metadata(self, job):
         self.save_result(metadata_rules.check_outcome(job))
         self.save_result(metadata_rules.check_errors(job))
-        self.save_result(metadata_rules.check_response_ratio(job))
 
     @lru_cache(maxsize=32)
     def compare_metadata(self, source_job, target_job):

--- a/src/arche/rules/metadata.py
+++ b/src/arche/rules/metadata.py
@@ -28,17 +28,6 @@ def check_outcome(job: Job) -> Result:
     return result
 
 
-def check_response_ratio(job: Job) -> Result:
-    requests_number = api.get_requests_count(job)
-    items_count = api.get_items_count(job)
-    result = Result("Responses Per Item Ratio")
-    result.add_info(
-        f"Number of responses / Number of scraped items - "
-        f"{round(requests_number / items_count, 2)}"
-    )
-    return result
-
-
 def compare_response_ratio(source_job: Job, target_job: Job) -> Result:
     """Compare request with response per item ratio"""
     s_ratio = round(

--- a/tests/rules/test_metadata.py
+++ b/tests/rules/test_metadata.py
@@ -2,7 +2,6 @@ from arche import SH_URL
 from arche.rules.metadata import (
     check_errors,
     check_outcome,
-    check_response_ratio,
     compare_finish_time,
     compare_response_ratio,
 )
@@ -78,21 +77,6 @@ def test_check_outcome(get_job, metadata, expected_messages):
 
     result = check_outcome(job)
     assert result == create_result("Job Outcome", expected_messages)
-
-
-response_ratio_inputs = [
-    (
-        {"totals": {"input_values": 1000}},
-        {"scrapystats": {"downloader/response_count": 2000}},
-        {Level.INFO: [("Number of responses / Number of scraped items - 2.0",)]},
-    )
-]
-
-
-@pytest.mark.parametrize("stats, metadata, expected_messages", response_ratio_inputs)
-def test_check_response_ratio(stats, metadata, expected_messages):
-    result = check_response_ratio(Job(metadata=metadata, stats=stats))
-    assert result == create_result("Responses Per Item Ratio", expected_messages)
 
 
 time_inputs = [


### PR DESCRIPTION
I removed this since I have never found this particular thing useful.

Note that responses ratio comparison is still in place.