### PR TITLE
Neat report

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,14 +5,6 @@
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
-
-# -- Path setup --------------------------------------------------------------
-import os
-import sys
-
-# sys.path.insert(0, os.path.abspath("../../src"))
-# nbsphinx_allow_errors = True
-
 # -- Project information -----------------------------------------------------
 
 from datetime import datetime
@@ -48,6 +40,7 @@ extensions = [
 autoapi_type = "python"
 autoapi_dirs = ["../../src"]
 nbsphinx_execute = "auto"
+nbsphinx_allow_errors = False
 
 
 def setup(app):

--- a/src/arche/arche.py
+++ b/src/arche/arche.py
@@ -203,8 +203,8 @@ class Arche:
 
     def run_customized_rules(self, items, tagged_fields):
         self.save_result(price_rules.compare_was_now(items.df, tagged_fields))
-        self.save_result(duplicate_rules.check_uniqueness(items.df, tagged_fields))
-        self.save_result(duplicate_rules.check_items(items.df, tagged_fields))
+        self.save_result(duplicate_rules.find_by_unique(items.df, tagged_fields))
+        self.save_result(duplicate_rules.find_by_name_url(items.df, tagged_fields))
         self.save_result(
             category_rules.get_coverage_per_category(
                 items.df, tagged_fields.get("category", []) + self.schema.enums

--- a/src/arche/arche.py
+++ b/src/arche/arche.py
@@ -221,7 +221,7 @@ class Arche:
     @lru_cache(maxsize=32)
     def compare_metadata(self, source_job, target_job):
         self.save_result(metadata_rules.compare_spider_names(source_job, target_job))
-        self.save_result(metadata_rules.compare_errors(source_job, target_job))
+        self.save_result(metadata_rules.check_errors(source_job, target_job))
         self.save_result(
             metadata_rules.compare_number_of_scraped_items(source_job, target_job)
         )

--- a/src/arche/data_quality_report.py
+++ b/src/arche/data_quality_report.py
@@ -48,14 +48,16 @@ class DataQualityReport:
                 bucket=bucket,
             )
 
-    def create_figures(self, items):
-        dup_items_result = duplicate_rules.check_items(items.df, self.schema.tags)
-        no_of_checked_duplicated_items = dup_items_result.items_count
-        no_of_duplicated_items = dup_items_result.err_items_count
+    def create_figures(self, items: CloudItems):
+        name_url_dups = self.report.results.get(
+            "Duplicates By **name_field, product_url_field** Tags",
+            duplicate_rules.find_by_name_url(items.df, self.schema.tags),
+        )
 
-        dup_skus_result = duplicate_rules.check_uniqueness(items.df, self.schema.tags)
-        no_of_checked_skus_items = dup_skus_result.items_count
-        no_of_duplicated_skus = dup_skus_result.err_items_count
+        uniques = self.report.results.get(
+            "Duplicates By **unique** Tag",
+            duplicate_rules.find_by_unique(items.df, self.schema.tags),
+        )
 
         price_was_now_result = price_rules.compare_was_now(items.df, self.schema.tags)
         no_of_price_warns = price_was_now_result.err_items_count
@@ -78,10 +80,10 @@ class DataQualityReport:
             items.job,
             crawlera_user,
             validation_errors,
-            no_of_duplicated_items,
-            no_of_checked_duplicated_items,
-            no_of_duplicated_skus,
-            no_of_checked_skus_items,
+            name_url_dups.err_items_count,
+            name_url_dups.items_count,
+            uniques.err_items_count,
+            uniques.items_count,
             no_of_price_warns,
             no_of_checked_price_items,
             tested=True,
@@ -95,11 +97,11 @@ class DataQualityReport:
             validation_errors,
             self.schema.tags.get("name_field", ""),
             self.schema.tags.get("product_url_field", ""),
-            no_of_checked_duplicated_items,
-            no_of_duplicated_items,
+            name_url_dups.items_count,
+            name_url_dups.err_items_count,
             self.schema.tags.get("unique", []),
-            no_of_checked_skus_items,
-            no_of_duplicated_skus,
+            uniques.items_count,
+            uniques.err_items_count,
             self.schema.tags.get("product_price_field", ""),
             self.schema.tags.get("product_price_was_field", ""),
             no_of_checked_price_items,

--- a/src/arche/report.py
+++ b/src/arche/report.py
@@ -22,7 +22,7 @@ class Report:
 
     @staticmethod
     def write_rule_name(rule_name: str) -> None:
-        print(f"\n{rule_name}:")
+        display(Markdown(f"{rule_name}:"))
 
     @classmethod
     def write(cls, text: str) -> None:

--- a/src/arche/report.py
+++ b/src/arche/report.py
@@ -3,7 +3,7 @@ from typing import Dict
 from arche import SH_URL
 from arche.rules.result import Level, Outcome, Result
 from colorama import Fore, Style
-from IPython.display import display, HTML
+from IPython.display import display, Markdown
 import numpy as np
 import pandas as pd
 import plotly.io as pio
@@ -58,12 +58,15 @@ class Report:
     def write_details(self, short: bool = False, keys_limit: int = 10) -> None:
         for result in self.results.values():
             if result.detailed_messages_count:
-                self.write_rule_name(
-                    f"{result.name} ({result.detailed_messages_count} message(s))"
+                display(
+                    Markdown(
+                        f"{result.name} ({result.detailed_messages_count} message(s)):"
+                    )
                 )
                 self.write_rule_details(result, short, keys_limit)
             for f in result.figures:
                 pio.show(f)
+            display(Markdown("<br>"))
 
     @classmethod
     def write_rule_details(
@@ -90,10 +93,7 @@ class Report:
                 keys = pd.Series(list(keys))
 
             sample = Report.sample_keys(keys, keys_limit)
-            msg = f"{len(keys)} items affected - {attribute}: {sample}"
-            display(HTML(msg))
-
-        display(HTML(f"<br>"))
+            display(Markdown(f"{len(keys)} items affected - {attribute}: {sample}"))
 
     @staticmethod
     def sample_keys(keys: pd.Series, limit: int) -> str:
@@ -104,9 +104,9 @@ class Report:
 
         def url(x: str) -> str:
             if SH_URL in x:
-                return f"<a href='{x}'>{x.split('/')[-1]}</a>"
+                return f"[{x.split('/')[-1]}]({x})"
             key, number = x.rsplit("/", 1)
-            return f"<a href='{SH_URL}/{key}/item/{number}'>{number}</a>"
+            return f"[{number}]({SH_URL}/{key}/item/{number})"
 
         # make links only for Cloud data
         if keys.dtype == np.dtype("object") and "/" in keys.iloc[0]:

--- a/src/arche/rules/category.py
+++ b/src/arche/rules/category.py
@@ -53,7 +53,6 @@ def get_difference(
             result.add_warning(
                 f"The difference is greater than {err_thr:.0%} for {len(errs)} value(s) of {c}"
             )
-
     if not category_names:
         result.add_info(Outcome.SKIPPED)
     return result

--- a/src/arche/rules/others.py
+++ b/src/arche/rules/others.py
@@ -101,7 +101,7 @@ def garbage_symbols(items: Items) -> Result:
             bad_texts = matches.stack().value_counts().index.sort_values().tolist()
             error = (
                 f"{len(error_keys)/len(items)*100:.1f}% of '{original_column}' "
-                f"values contain {[t[:20] for t in bad_texts]}"
+                f"values contain `{', '.join([t[:20] for t in bad_texts])}`"
             )
             errors[error] = list(error_keys)
             row_keys = row_keys.union(error_keys)

--- a/src/arche/tools/helpers.py
+++ b/src/arche/tools/helpers.py
@@ -1,5 +1,6 @@
 import datetime as d
 import os
+from typing import Optional
 
 
 class CollectionKey:
@@ -33,10 +34,15 @@ def is_job_key(value):
     return False
 
 
-def ms_to_time(ms):
+def ms_to_time(ms: int) -> Optional[str]:
+    """Convert ms to human time, stripping ms.
+
+    >>> ms_to_time(12345678901)
+    142 days, 21:21:18
+    """
     if ms is None:
         return None
-    return str(d.timedelta(milliseconds=ms))[:-7] or str(d.timedelta(milliseconds=ms))
+    return str(d.timedelta(milliseconds=ms))[:-7]
 
 
 def ratio_diff(source, target):

--- a/src/arche/tools/helpers.py
+++ b/src/arche/tools/helpers.py
@@ -36,7 +36,7 @@ def is_job_key(value):
 def ms_to_time(ms):
     if ms is None:
         return None
-    return str(d.timedelta(milliseconds=ms))
+    return str(d.timedelta(milliseconds=ms))[:-7] or str(d.timedelta(milliseconds=ms))
 
 
 def ratio_diff(source, target):

--- a/tests/rules/test_duplicates.py
+++ b/tests/rules/test_duplicates.py
@@ -1,5 +1,5 @@
 import arche.rules.duplicates as duplicates
-from arche.rules.result import Level
+from arche.rules.result import Level, Outcome
 from conftest import create_result
 import numpy as np
 import pandas as pd
@@ -7,16 +7,7 @@ import pytest
 
 
 check_items_inputs = [
-    (
-        {},
-        {},
-        {
-            Level.INFO: [
-                ("'name_field' and 'product_url_field' tags were not found in schema",)
-            ]
-        },
-        0,
-    ),
+    ({}, {}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
     (
         {"name": ["bob", "bob", "bob", "bob"], "url": ["u1", "u1", "2", "u1"]},
         {"name_field": ["name"], "product_url_field": ["url"]},
@@ -56,7 +47,7 @@ def test_check_items(data, tagged_fields, expected_messages, expected_err_items_
 
 
 check_uniqueness_inputs = [
-    ({}, {}, {Level.INFO: [("'unique' tag was not found in schema",)]}, 0),
+    ({}, {}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
     (
         {"id": ["0", "0", "1"]},
         {"unique": ["id"]},

--- a/tests/rules/test_duplicates.py
+++ b/tests/rules/test_duplicates.py
@@ -6,54 +6,14 @@ import pandas as pd
 import pytest
 
 
-check_items_inputs = [
-    ({}, {}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
-    (
-        {"name": ["bob", "bob", "bob", "bob"], "url": ["u1", "u1", "2", "u1"]},
-        {"name_field": ["name"], "product_url_field": ["url"]},
-        {
-            Level.ERROR: [
-                (
-                    "3 duplicate(s) with same name and url",
-                    None,
-                    {"same 'bob' name and 'u1' url": [0, 1, 3]},
-                )
-            ]
-        },
-        3,
-    ),
-    (
-        {"name": ["john", "bob"], "url": ["url1", "url1"]},
-        {"name_field": ["name"], "product_url_field": ["url"]},
-        {},
-        0,
-    ),
-]
-
-
-@pytest.mark.parametrize(
-    "data, tagged_fields, expected_messages, expected_err_items_count",
-    check_items_inputs,
-)
-def test_check_items(data, tagged_fields, expected_messages, expected_err_items_count):
-    df = pd.DataFrame(data)
-    result = duplicates.check_items(df, tagged_fields)
-    assert result == create_result(
-        "Duplicated Items",
-        expected_messages,
-        items_count=len(df),
-        err_items_count=expected_err_items_count,
-    )
-
-
-check_uniqueness_inputs = [
+unique_inputs = [
     ({}, {}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
     (
         {"id": ["0", "0", "1"]},
         {"unique": ["id"]},
         {
             Level.ERROR: [
-                ("'id' contains 1 duplicated value(s)", None, {"same '0' id": [0, 1]})
+                ("id contains 1 duplicated value(s)", None, {"same '0' `id`": [0, 1]})
             ]
         },
         2,
@@ -67,14 +27,14 @@ check_uniqueness_inputs = [
         {
             Level.ERROR: [
                 (
-                    "'id' contains 1 duplicated value(s)",
+                    "id contains 1 duplicated value(s)",
                     None,
-                    {"same '47' id": [i for i in range(6)]},
+                    {"same '47' `id`": [i for i in range(6)]},
                 ),
                 (
-                    "'name' contains 2 duplicated value(s)",
+                    "name contains 2 duplicated value(s)",
                     None,
-                    {"same 'Juan' name": [1, 2], "same 'Walt' name": [0, 3, 4]},
+                    {"same 'Juan' `name`": [1, 2], "same 'Walt' `name`": [0, 3, 4]},
                 ),
             ]
         },
@@ -85,53 +45,93 @@ check_uniqueness_inputs = [
 
 
 @pytest.mark.parametrize(
-    "data, tagged_fields, expected_messages, expected_err_items_count",
-    check_uniqueness_inputs,
+    "data, tagged_fields, expected_messages, expected_err_items_count", unique_inputs
 )
-def test_check_uniqueness(
+def test_find_by_unique(
     data, tagged_fields, expected_messages, expected_err_items_count
 ):
     df = pd.DataFrame(data)
-    assert duplicates.check_uniqueness(df, tagged_fields) == create_result(
-        "Uniqueness",
+    assert duplicates.find_by_unique(df, tagged_fields) == create_result(
+        "Duplicates By **unique** Tag",
         expected_messages,
         items_count=len(df),
         err_items_count=expected_err_items_count,
     )
 
 
-find_by_inputs = [
-    (
-        {"id": ["0", "0", "1"]},
-        ["id"],
-        {Level.ERROR: [("2 duplicate(s) with same id", None, {"same '0' id": [0, 1]})]},
-        2,
-    ),
-    ({"id": ["0", "1", "2"]}, ["id"], {}, 0),
-    (
-        {"id": [np.nan, "9", "9"], "city": [np.nan, "Talca", "Talca"]},
-        ["id", "city"],
-        {
-            Level.ERROR: [
-                (
-                    "2 duplicate(s) with same id, city",
-                    None,
-                    {"same '9' id 'Talca' city": [1, 2]},
-                )
-            ]
-        },
-        2,
-    ),
-]
-
-
 @pytest.mark.parametrize(
-    "data, columns, expected_messages, expected_err_items_count", find_by_inputs
+    "data, columns, expected_messages, expected_err_items_count",
+    [
+        (
+            {"id": ["0", "0", "1"]},
+            ["id"],
+            {
+                Level.ERROR: [
+                    ("2 duplicate(s) with same id", None, {"same '0' `id`": [0, 1]})
+                ]
+            },
+            2,
+        ),
+        ({"id": ["0", "1", "2"]}, ["id"], {}, 0),
+        (
+            {"id": [np.nan, "9", "9"], "city": [np.nan, "Talca", "Talca"]},
+            ["id", "city"],
+            {
+                Level.ERROR: [
+                    (
+                        "2 duplicate(s) with same id, city",
+                        None,
+                        {"same '9' `id`, 'Talca' `city`": [1, 2]},
+                    )
+                ]
+            },
+            2,
+        ),
+    ],
 )
 def test_find_by(data, columns, expected_messages, expected_err_items_count):
     df = pd.DataFrame(data)
     assert duplicates.find_by(df, columns) == create_result(
-        "Items Uniqueness By Columns",
+        "Duplicates",
+        expected_messages,
+        items_count=len(df),
+        err_items_count=expected_err_items_count,
+    )
+
+
+@pytest.mark.parametrize(
+    "data, tagged_fields, expected_messages, expected_err_items_count",
+    [
+        ({}, {}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
+        (
+            {"name": ["bob", "bob", "bob", "bob"], "url": ["u1", "u1", "2", "u1"]},
+            {"name_field": ["name"], "product_url_field": ["url"]},
+            {
+                Level.ERROR: [
+                    (
+                        "3 duplicate(s) with same name, url",
+                        None,
+                        {"same 'bob' `name`, 'u1' `url`": [0, 1, 3]},
+                    )
+                ]
+            },
+            3,
+        ),
+        (
+            {"name": ["john", "bob"], "url": ["url1", "url1"]},
+            {"name_field": ["name"], "product_url_field": ["url"]},
+            {},
+            0,
+        ),
+    ],
+)
+def test_find_by_name_url(
+    data, tagged_fields, expected_messages, expected_err_items_count
+):
+    df = pd.DataFrame(data)
+    result = duplicates.find_by_name_url(df, tagged_fields)
+    assert result == create_result(
+        "Duplicates By **name_field, product_url_field** Tags",
         expected_messages,
         items_count=len(df),
         err_items_count=expected_err_items_count,

--- a/tests/rules/test_metadata.py
+++ b/tests/rules/test_metadata.py
@@ -13,21 +13,17 @@ import pytest
 
 error_input = [
     (
-        {"log_count/ERROR": 10},
+        {"log_count/ERROR": 5},
         {
             Level.ERROR: [
                 (
-                    "10 error(s)",
-                    (
-                        f"Errors for 112358/13/21 - {SH_URL}/112358/13/21/"
-                        f"log?filterType=error&filterAndHigher"
-                    ),
+                    f"5 error(s) - {SH_URL}/112358/13/21/log?filterType=error&filterAndHigher",
                 )
             ]
         },
     ),
-    ({}, {Level.INFO: [("No errors",)]}),
-    ({"log_count/ERROR": 0}, {Level.INFO: [("No errors",)]}),
+    ({}, {}),
+    ({"log_count/ERROR": 0}, {}),
 ]
 
 
@@ -37,8 +33,7 @@ def test_check_errors(get_job, error_count, expected_messages):
     job.metadata = {"scrapystats": error_count}
     job.key = "112358/13/21"
 
-    result = check_errors(job)
-    assert result == create_result("Job Errors", expected_messages)
+    assert check_errors(job) == create_result("Job Errors", expected_messages)
 
 
 outcome_input = [
@@ -67,7 +62,7 @@ outcome_input = [
         {Level.ERROR: [("Job has 'finished' state, 'None' close reason",)]},
     ),
     ({}, {Level.ERROR: [("Job has 'None' state, 'None' close reason",)]}),
-    ({"state": "finished", "close_reason": "finished"}, {Level.INFO: [("Finished",)]}),
+    ({"state": "finished", "close_reason": "finished"}, {}),
 ]
 
 

--- a/tests/rules/test_others.py
+++ b/tests/rules/test_others.py
@@ -92,11 +92,11 @@ dirty_inputs = [
                     "100.0% (2) items affected",
                     None,
                     {
-                        "100.0% of 'name' values contain [' ', '-->', '<!--']": [0, 1],
-                        "50.0% of 'address' values contain ['&AMP']": [0],
+                        "100.0% of 'name' values contain ` , -->, <!--`": [0, 1],
+                        "50.0% of 'address' values contain `&AMP`": [0],
                         (
                             "50.0% of 'phone' values contain "
-                            "['.sx-prime-pricing-lo', '</h1>', '<h1>']"
+                            "`.sx-prime-pricing-lo, </h1>, <h1>`"
                         ): [0],
                     },
                 )

--- a/tests/rules/test_price.py
+++ b/tests/rules/test_price.py
@@ -1,5 +1,5 @@
 import arche.rules.price as p
-from arche.rules.result import Level
+from arche.rules.result import Level, Outcome
 from conftest import create_result
 import numpy as np
 import pandas as pd
@@ -32,21 +32,7 @@ was_now_inputs = [
         },
         3,
     ),
-    (
-        {},
-        {"product_price_field": ["name"]},
-        {
-            Level.INFO: [
-                (
-                    (
-                        "product_price_field or product_price_was_field tags were not found "
-                        "in schema"
-                    ),
-                )
-            ]
-        },
-        0,
-    ),
+    ({}, {"product_price_field": ["name"]}, {Level.INFO: [(Outcome.SKIPPED,)]}, 0),
     (
         {
             "original_price": [10, 15, 40, None, 30, None, "60", "56.6", "30.2"],

--- a/tests/rules/test_result.py
+++ b/tests/rules/test_result.py
@@ -55,12 +55,13 @@ def test_tensors_not_equal(source, target):
 
 
 @pytest.mark.parametrize(
-    "message, stats, expected_details",
+    "message, stats, exp_md_output, exp_txt_outputs",
     [
         (
             {Level.INFO: [("summary", "very detailed message")]},
             [pd.Series([1, 2], name="Fields coverage")],
-            "\nrule name here:\n\tsummary\nvery detailed message\n",
+            "rule name here:",
+            ["\tsummary", "very detailed message"],
         ),
         (
             {Level.INFO: [("summary",)]},
@@ -69,17 +70,20 @@ def test_tensors_not_equal(source, target):
                     {"s": [0.25]}, index=["us"], name="Coverage for boolean fields"
                 )
             ],
-            "\nrule name here:\n\tsummary\n",
+            "rule name here:",
+            ["\tsummary"],
         ),
     ],
 )
-def test_show(mocker, capsys, message, stats, expected_details):
+def test_show(mocker, capsys, message, stats, exp_md_output, exp_txt_outputs):
     mock_pio_show = mocker.patch("plotly.io.show", autospec=True)
+    mocked_md = mocker.patch("arche.report.Markdown", autospec=True)
+    mocked_print = mocker.patch("builtins.print", autospec=True)
     res = create_result("rule name here", message, stats=stats)
     res.show()
     mock_pio_show.assert_called_once_with(res.figures[0])
-    # capsys captures IPython.display.clear_output()
-    assert capsys.readouterr().out == f"\x1b[2K\r\x1b[2K\r{expected_details}"
+    mocked_md.assert_called_with(exp_md_output)
+    mocked_print.assert_has_calls(mocker.call(o) for o in exp_txt_outputs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_arche.py
+++ b/tests/test_arche.py
@@ -142,8 +142,8 @@ def test_arche_dataframe(mocker):
         "JSON Schema Validation",
         "Tags",
         "Compare Price Was And Now",
-        "Uniqueness",
-        "Duplicated Items",
+        "Duplicates By **unique** Tag",
+        "Duplicates By **name_field, product_url_field** Tags",
         "Coverage For Scraped Categories",
         "Category Coverage Difference",
         "Compare Prices For Same Urls",
@@ -251,7 +251,7 @@ def test_validate_with_json_schema(mocker, get_job_items, get_schema):
 
 
 def test_validate_with_json_schema_fails(mocker, get_job_items, get_schema):
-    mocked_html = mocker.patch("arche.report.Markdown", autospec=True)
+    mocked_md = mocker.patch("arche.report.Markdown", autospec=True)
     url = f"{SH_URL}/112358/13/21/item/1"
     res = create_result(
         "JSON Schema Validation",
@@ -272,7 +272,7 @@ def test_validate_with_json_schema_fails(mocker, get_job_items, get_schema):
 
     assert len(a.report.results) == 1
     assert a.report.results.get("JSON Schema Validation") == res
-    mocked_html.assert_any_call(
+    mocked_md.assert_any_call(
         f"1 items affected - 'price' is a required property: [1]({url})"
     )
 

--- a/tests/test_arche.py
+++ b/tests/test_arche.py
@@ -251,7 +251,7 @@ def test_validate_with_json_schema(mocker, get_job_items, get_schema):
 
 
 def test_validate_with_json_schema_fails(mocker, get_job_items, get_schema):
-    mocked_html = mocker.patch("arche.report.HTML", autospec=True)
+    mocked_html = mocker.patch("arche.report.Markdown", autospec=True)
     url = f"{SH_URL}/112358/13/21/item/1"
     res = create_result(
         "JSON Schema Validation",
@@ -273,7 +273,7 @@ def test_validate_with_json_schema_fails(mocker, get_job_items, get_schema):
     assert len(a.report.results) == 1
     assert a.report.results.get("JSON Schema Validation") == res
     mocked_html.assert_any_call(
-        f"1 items affected - 'price' is a required property: <a href='{url}'>1</a>"
+        f"1 items affected - 'price' is a required property: [1]({url})"
     )
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -20,26 +20,31 @@ import pytest
                     {Level.INFO: [("summary", "other detailed message")]},
                 ),
             ],
-            (
-                "\nrule name here (1 message(s)):\nvery detailed message\n"
-                "\nother result there (1 message(s)):\nother detailed message\n"
-            ),
+            [
+                "rule name here (1 message(s)):",
+                "<br>",
+                "other result there (1 message(s)):",
+                "<br>",
+            ],
         ),
         (
             [("everything is fine", {Level.INFO: [("summary",)]})],
-            "\neverything is fine (1 message(s)):\n",
+            ["everything is fine (1 message(s)):"],
         ),
     ],
 )
 def test_write_details(mocker, get_df, capsys, messages, expected_details):
     mock_pio_show = mocker.patch("plotly.io.show", autospec=True)
+    md_mock = mocker.patch("arche.report.Markdown", autospec=True)
+
     r = Report()
     for m in messages:
         result = create_result(*m, stats=[get_df])
         r.save(result)
     r.write_details()
     mock_pio_show.assert_called_with(result.figures[0])
-    assert capsys.readouterr().out == expected_details
+    calls = [mocker.call(e) for e in expected_details]
+    md_mock.assert_has_calls(calls, any_order=True)
 
 
 @pytest.mark.parametrize(
@@ -109,20 +114,17 @@ def test_write_rule_details(capsys, message, expected_details):
             {"something happened": set(["https://app.scrapinghub.com/p/1/1/1/item/0"])},
             False,
             10,
-            [
-                f"1 items affected - something happened: <a href='{SH_URL}/1/1/1/item/0'>0</a>"
-            ],
+            [f"1 items affected - something happened: [0]({SH_URL}/1/1/1/item/0)"],
         ),
+        ({"html '</br>'": [1]}, False, 10, ["1 items affected - html '</br>': 1"]),
     ],
 )
 def test_write_detailed_errors(mocker, errors, short, keys_limit, expected_messages):
     mocker.patch("pandas.Series.sample", return_value=pd.Series("5"), autospec=True)
-    html_mock = mocker.patch("arche.report.HTML", autospec=True)
+    md_mock = mocker.patch("arche.report.Markdown", autospec=True)
     Report.write_detailed_errors(errors, short, keys_limit)
-    calls = []
-    for m in expected_messages:
-        calls.append(mocker.call(m))
-    html_mock.assert_has_calls(calls, any_order=True)
+    calls = [mocker.call(m) for m in expected_messages]
+    md_mock.assert_has_calls(calls, any_order=True)
 
 
 @pytest.mark.parametrize(
@@ -132,21 +134,21 @@ def test_write_detailed_errors(mocker, errors, short, keys_limit, expected_messa
             pd.Series(f"{SH_URL}/112358/13/21/item/0"),
             5,
             pd.Series(f"{SH_URL}/112358/13/21/item/5"),
-            f"<a href='{SH_URL}/112358/13/21/item/0'>0</a>",
+            f"[0]({SH_URL}/112358/13/21/item/0)",
         ),
         (
             pd.Series([f"{SH_URL}/112358/13/21/item/{i}" for i in range(20)]),
             10,
             pd.Series(f"{SH_URL}/112358/13/21/item/5"),
-            f"<a href='{SH_URL}/112358/13/21/item/5'>5</a>",
+            f"[5]({SH_URL}/112358/13/21/item/5)",
         ),
         (
             pd.Series("112358/13/21/0"),
             1,
             pd.Series("112358/13/21/0"),
-            f"<a href='{SH_URL}/112358/13/21/item/0'>0</a>",
+            f"[0]({SH_URL}/112358/13/21/item/0)",
         ),
-        (pd.Series([0, 1]), 1, pd.Series([0, 1]), f"0, 1"),
+        (pd.Series([0, 1]), 1, pd.Series([0, 1]), "0, 1"),
     ],
 )
 def test_sample_keys(mocker, keys, limit, sample_mock, expected_sample):

--- a/tests/tools/test_helpers.py
+++ b/tests/tools/test_helpers.py
@@ -5,6 +5,7 @@ import pytest
 def test_ms_to_time():
     assert h.ms_to_time(None) is None
     assert h.ms_to_time(1000) == "0:00:01"
+    assert h.ms_to_time(2203085216) == "25 days, 11:58:05"
 
 
 input_ratio_values = [

--- a/tests/tools/test_helpers.py
+++ b/tests/tools/test_helpers.py
@@ -4,7 +4,6 @@ import pytest
 
 def test_ms_to_time():
     assert h.ms_to_time(None) is None
-    assert h.ms_to_time(1000) == "0:00:01"
     assert h.ms_to_time(2203085216) == "25 days, 11:58:05"
 
 


### PR DESCRIPTION
Partially covers #119 :
1. Mark rules SKIPPED if corresponding tags were not found
2. Simplify job errors
3. Partially switched to Markdown to fix non escaped html entities in garbage symbols 
Before:
![Screenshot 2019-06-25 at 16 19 34](https://user-images.githubusercontent.com/10396557/60132431-79109180-9769-11e9-95e3-a8d2d9624f40.png)
After:
![Screenshot 2019-06-25 at 18 02 55](https://user-images.githubusercontent.com/10396557/60136909-7fa40680-9773-11e9-9513-3ab768ede103.png)
