### PR TITLE
Base API for field distribution comparison

### DIFF
--- a/src/arche/rules/stats.py
+++ b/src/arche/rules/stats.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from arche.rules.result import Result, Outcome
+
+
+def compare_field_distribution(group1, group2, field):
+    groups_diff = np.abs(np.mean(group1) - np.mean(group2))
+    p_value = np.mean(
+        list(_compare_sample_diffs_to_base_diff(group1, group2, groups_diff))
+    )
+    result = Result("Field distribution")
+    if p_value <= 0.05:
+        result.add_warning(
+            Outcome.FAILED, detailed=f'"{field}" distribution differs between jobs'
+        )
+
+    return result
+
+
+def _compare_sample_diffs_to_base_diff(group1, group2, base_diff, N=1000):
+    m = len(group1)
+    pool = np.hstack([group1, group2])
+    for _ in range(N):
+        np.random.shuffle(pool)
+        group1 = pool[:m]
+        group2 = pool[m:]
+        yield np.abs(np.mean(group1) - np.mean(group2)) > base_diff

--- a/tests/rules/test_stats.py
+++ b/tests/rules/test_stats.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from conftest import create_result
+from arche.rules.result import Level, Outcome
+from arche.rules.stats import compare_field_distribution
+
+np.random.seed(42)
+
+
+def test_compare_field_distribution_fail(mocker):
+    prices_1 = np.random.normal(126.99, 25.3, size=1000)
+    prices_2 = np.random.normal(299.56, 78.9, size=2000)
+    result = compare_field_distribution(prices_1, prices_2, field="price")
+
+    assert result == create_result(
+        "Field distribution",
+        {
+            Level.WARNING: [
+                (Outcome.FAILED, '"price" distribution differs between jobs')
+            ]
+        },
+    )
+
+
+def test_compare_field_distribution_succeed(mocker):
+    prices_1 = np.random.normal(126.99, 25.3, size=790)
+    prices_2 = np.random.normal(129.27, 22.78, size=540)
+    result = compare_field_distribution(prices_1, prices_2, field="price")
+
+    assert result == create_result("Field distribution", {})


### PR DESCRIPTION
Fix #148 
This is a draft PR to check the API.
The idea is that we'll be able to set a job key, a dataframe, or a list as input for comparison.
Also, I'll add options for `alpha` and `N`.

What do you think?

The approach here is https://rasbt.github.io/mlxtend/user_guide/evaluate/permutation_test/